### PR TITLE
Improve image quality after uploading the image

### DIFF
--- a/src/formats.ts
+++ b/src/formats.ts
@@ -1,1 +1,11 @@
-export const supportedExtensions = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg'];
+export const supportedExtensions = [
+  "jpg",
+  "jpeg",
+  "png",
+  "gif",
+  "bmp",
+  "svg",
+  "webp",
+  "HEIC",
+];
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -154,7 +154,7 @@ export default class ImgBBUploader extends Plugin {
 			},
 			params: formParams
 		}).then((res) => {
-			let replaceMarkdownText = `![](${res.data.data.display_url})`;
+			let replaceMarkdownText = `![](${res.data.data.url})`;
 			// Show MD syntax using uploaded image URL, in Obsidian Editor
 			this.replaceText(editor, pastePlaceText, replaceMarkdownText);
 		}).catch((err) => {


### PR DESCRIPTION
First, i want to say thank you for making this plugin. I have been a user of obsidian imgur plugin for a year and now because of the broken api, I have switched using yours.

However, I noticed that the image quality after upload quite blurry. I have tried to look up the documentation on ImgBB and found out that you are using `display_url` field after receive a response from an API call. This would match with the `medium` resolution of the image after it has been processing on the imgBB server.

To fix that, i changed the field to `url`, which match the highest res of the image. I also expand more image types such as WEBp and HEIC when uploaded.

Here's the example results difference

Before

<img width="3060" height="1828" alt="image" src="https://github.com/user-attachments/assets/07839734-983a-4134-bfd1-fdc04fcebad4" />

After

<img width="3060" height="1828" alt="image" src="https://github.com/user-attachments/assets/58c3d82d-a8ac-4846-84a0-b15332011967" />
